### PR TITLE
Remove Recommends From Manifest

### DIFF
--- a/system.json
+++ b/system.json
@@ -124,23 +124,5 @@
     "allowBugReporter": true
   },
   "relationships": {
-    "recommends": [
-      {
-        "id": "ose-advancedfantasytome",
-        "type": "module",
-        "compatibility": {
-          "minimum": "25.07.01",
-          "verified": "25.07.03"
-        }
-      },
-      {
-        "id": "classicfantasycompendium",
-        "type": "module",
-        "compatibility": {
-          "minimum": "1.0.0",
-          "verified": "1.0.99"
-        }
-      }
-    ]
   }
 }


### PR DESCRIPTION
Remove the recommended modules section from the manifest to avoid the installation dialogs on update.